### PR TITLE
Add PresenceValidatable conformance to Count validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
       - name: Run tests
         run: |
           xcodebuild test \
             -workspace .github/package.xcworkspace \
             -scheme Validations \
-            -destination "platform=iOS Simulator,name=iPhone 16,OS=18.1"
+            -destination "platform=iOS Simulator,name=iPhone 16,OS=18.5"
           xcodebuild test \
             -workspace .github/package.xcworkspace \
             -scheme Validations \

--- a/Sources/Validations/Validator/Presets/Count.swift
+++ b/Sources/Validations/Validator/Presets/Count.swift
@@ -1,11 +1,10 @@
-public struct Count<Value: Collection, Range: RangeExpression<Int>>: Validator {
+public struct Count<Value: Collection, Range: RangeExpression<Int>>: Validator, PresenceValidatable {
     public var value: Value?
 
     @usableFromInline
     var range: Range
 
-    @usableFromInline
-    var allowsNil = false
+    public var presenceOption: PresenceOption = .required(allowsEmpty: true)
 
     @inlinable
     public init(of value: Value?, within range: Range) {
@@ -21,23 +20,13 @@ public struct Count<Value: Collection, Range: RangeExpression<Int>>: Validator {
 
     @inlinable
     public func validate() throws {
-        guard let value else {
-            if !allowsNil {
-                throw ValidationError(reasons: .count)
-            }
+        guard let presenceValue = try validatePresence(resolvingErrorWithReasons: .count) else {
             return
         }
 
-        if !range.contains(value.count) {
+        if !range.contains(presenceValue.count) {
             throw ValidationError(reasons: .count)
         }
-    }
-
-    @inlinable
-    func allowsNil(_ enabled: Bool = true) -> Self {
-        var `self` = self
-        self.allowsNil = enabled
-        return self
     }
 }
 

--- a/Tests/Validations/Presets/CountTests.swift
+++ b/Tests/Validations/Presets/CountTests.swift
@@ -47,16 +47,30 @@ struct CountTests {
     }
 
     @Test
-    func empty() {
-        #expect(throws: Never.self) { try Count(of: "", within: 0...).validate() }
-        #expect(throws: Never.self) { try Count(of: "", exact: 0).validate() }
-        #expect(throws: Never.self) { try Count(of: [Int](), within: 0...).validate() }
-        #expect(throws: Never.self) { try Count(of: [Int](), exact: 0).validate() }
-        #expect(throws: Never.self) { try Count(of: [Int?](), within: 0...).validate() }
-        #expect(throws: Never.self) { try Count(of: [Int?](), exact: 0).validate() }
-        #expect(throws: Never.self) { try Count(of: [Int]?([]), within: 0...).validate() }
-        #expect(throws: Never.self) { try Count(of: [Int]?([]), exact: 0).validate() }
-        #expect(throws: Never.self) { try Count(of: [Int?]?([]), within: 0...).validate() }
-        #expect(throws: Never.self) { try Count(of: [Int?]?([]), exact: 0).validate() }
+    func empty_allowed() {
+        #expect(throws: Never.self) { try Count(of: "", within: 3...).validate() }
+        #expect(throws: Never.self) { try Count(of: "", exact: 3).validate() }
+        #expect(throws: Never.self) { try Count(of: [Int](), within: 3...).validate() }
+        #expect(throws: Never.self) { try Count(of: [Int](), exact: 3).validate() }
+        #expect(throws: Never.self) { try Count(of: [Int?](), within: 3...).validate() }
+        #expect(throws: Never.self) { try Count(of: [Int?](), exact: 3).validate() }
+        #expect(throws: Never.self) { try Count(of: [Int]?([]), within: 3...).validate() }
+        #expect(throws: Never.self) { try Count(of: [Int]?([]), exact: 3).validate() }
+        #expect(throws: Never.self) { try Count(of: [Int?]?([]), within: 3...).validate() }
+        #expect(throws: Never.self) { try Count(of: [Int?]?([]), exact: 3).validate() }
+    }
+
+    @Test
+    func empty_disallowed() {
+        #expect(throws: ValidationError.self) { try Count(of: "", within: 0...).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: "", exact: 0).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: [Int](), within: 0...).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: [Int](), exact: 0).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: [Int?](), within: 0...).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: [Int?](), exact: 0).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: [Int]?([]), within: 0...).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: [Int]?([]), exact: 0).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: [Int?]?([]), within: 0...).allowsEmpty(false).validate() }
+        #expect(throws: ValidationError.self) { try Count(of: [Int?]?([]), exact: 0).allowsEmpty(false).validate() }
     }
 }


### PR DESCRIPTION
Support cases where count validation should be skipped for empty collections while still enforcing range requirements (e.g., 3..<11) when present.